### PR TITLE
Fix styles

### DIFF
--- a/assets/ananke/css/_styles.css
+++ b/assets/ananke/css/_styles.css
@@ -449,6 +449,7 @@ textarea {
 }
 
 @media all and (min-width: 1200px) {
+
   .f4-5-l {
     font-size: 1.12rem;
   }
@@ -467,6 +468,7 @@ textarea {
 }
 
 @media all and (min-width: 768px) and (max-width: 1200px) {
+
   .f0-m {
     font-size: 0;
   }
@@ -524,6 +526,11 @@ textarea {
   .page-content {
     padding-bottom: 238.5px;    /* Footer height */
   }
+
+  #btnBackToTop {
+    bottom: 76px;
+    right: 20px;
+  }
 }
 
 @media all and (max-width: 768px) {
@@ -559,7 +566,7 @@ textarea {
   }
 
   #btnBackToTop {
-    bottom: 20px;
+    bottom: 135px;
     right: 20px;
   }
 

--- a/assets/ananke/css/_styles.css
+++ b/assets/ananke/css/_styles.css
@@ -283,7 +283,7 @@ figcaption h4 {
 
 /* make footer bottom on small page */
 .page-content {
-  padding-bottom: 225px;    /* Footer height */
+  padding-bottom: 218.5px;    /* Footer height */
 }
 
 /* make footer bottom on small page */
@@ -505,11 +505,28 @@ textarea {
 
 }
 
-@media all and (max-width: 768px) {
+@media all and (max-width: 479px) {
+  
+  .page-content {
+    padding-bottom: 240.8px;    /* Footer height */
+  }
+}
+
+@media all and (min-width: 480px) and (max-width: 768px) {
 
   .page-content {
-    padding-bottom: 229px;    /* Footer height */
+    padding-bottom: 227px;    /* Footer height */
   }
+}
+
+@media all and (min-width: 769px) and (max-width: 1199px) {
+
+  .page-content {
+    padding-bottom: 238.5px;    /* Footer height */
+  }
+}
+
+@media all and (max-width: 768px) {
 
   .max-h-20-ns{
     max-height: 20rem;

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -18,7 +18,7 @@
 {{/* Derive the section name  */}}
 {{ $main_section_name := index (.Site.Params.mainSections) 0 }}
 
-<div class="pv4 w-120 w-60-l mw7-m center">
+<div class="pt4 w-120 w-60-l mw7-m center">
 
   {{ $n_posts := $.Param "recent_posts_number" | default 3 }}
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,10 +8,6 @@
 </article>
 {{ end }}
 
-<div class="final-message-font center mt2 tc f4 f5-ns fw4 pt4-ns ph5-ns lh-title" style="color:{{ $.Param "final_message_color" | default "#181818" }};">
-    {{ .Params.final_message }}
-</div>
-
 {{ if ne .Params.layout "contacts-with-google-form" }}
     {{ if .Site.Params.footerContactButton }}
         {{ partial "contact-us-btn.html" . }}

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -1,7 +1,7 @@
 {{ define "header" }}{{ partial "page-header.html" . }}{{ end }}
 {{ define "main" }}
 <div class="flex-l mt2 center color-link">
-    <div class="center mb5-m mb4">
+    <div class="center">
 
         {{ if eq .Params.layout "privacy"}}
         <div class="center cf pv5 pv4-m ph5 ph3-ns mw8">

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -1,7 +1,7 @@
 {{ define "header" }}{{ partial "page-header.html" . }}{{ end }}
 {{ define "main" }}
 <div class="flex-l mt2 center color-link">
-    <div class="center mb6-m mb5">
+    <div class="center mb5-m mb4">
 
         {{ if eq .Params.layout "privacy"}}
         <div class="center cf pv5 pv4-m ph5 ph3-ns mw8">
@@ -42,10 +42,6 @@
         {{ end }}
 
     </div>
-</div>
-
-<div class="final-message-font center tc f4 f5-ns fw4 ph5-ns lh-title" style="color:{{ $.Param "final_message_color" | default "#454545" }};">
-    {{ .Params.final_message }}
 </div>
 
 {{ if ne .Params.layout "contacts-with-google-form" }}

--- a/layouts/partials/consent.html
+++ b/layouts/partials/consent.html
@@ -21,7 +21,13 @@
     #consent-overlay button.btn.save-consent {background: rgba(0,0,0,0.6); font-weight: normal;}
     .approve-consent { color: #2F2F2F !important; }
 
-    @media (max-width: 767px) {
+    @media (max-width: 456px) {
+        #consent-notice {min-height: 120px; padding-top: 1rem; padding-bottom: 1rem; padding-left: 0.1rem; padding-right: 0.3rem; width: 100%;}
+        #consent-notice span {display: block; font-size: 0.73rem; padding-top: 3px; margin-bottom: 1.2rem; margin-right: 0.7rem; margin-left: 0.7rem;}
+        #consent-notice button.btn {position: relative; font-size: 10.16px; font-weight: normal; height: 1.8rem; padding: 0.3rem 0.4rem; margin-left: 0.3rem;}
+    }
+
+    @media (min-width: 457px) and (max-width: 1080px) {
         #consent-overlay > div {padding: 1.75rem 1rem;}
         #consent-notice span {display: block; padding-top: 3px; margin-bottom: 1.5rem;}
         #consent-notice button.btn {position: relative; bottom: 4px;}

--- a/layouts/partials/contact-us-btn.html
+++ b/layouts/partials/contact-us-btn.html
@@ -1,4 +1,4 @@
-<div class="tc mb4 mt4">
+<div class="tc mv4">
   <a class="f6 input-text-font link w-20 w-30-m w-50-ns dim br-10 ph3 pv2-5 dib"
      style="background-color:{{ $.Param "footer_contact_button_color" | default "#555555" }}; color:{{ $.Param "footer_contact_button_text_color" | default "#ffffff" }};" href="{{ .Site.Params.footerContactButtonPath }}">
   {{ .Site.Params.footerContactButton }}

--- a/layouts/partials/contact-us-btn.html
+++ b/layouts/partials/contact-us-btn.html
@@ -1,4 +1,4 @@
-<div class="tc mb4">
+<div class="tc mb4 mt4">
   <a class="f6 input-text-font link w-20 w-30-m w-50-ns dim br-10 ph3 pv2-5 dib"
      style="background-color:{{ $.Param "footer_contact_button_color" | default "#555555" }}; color:{{ $.Param "footer_contact_button_text_color" | default "#ffffff" }};" href="{{ .Site.Params.footerContactButtonPath }}">
   {{ .Site.Params.footerContactButton }}

--- a/layouts/partials/contacts-with-google-form.html
+++ b/layouts/partials/contacts-with-google-form.html
@@ -3,7 +3,7 @@
 {{ $form := where .Site.RegularPages "Section" "in" $mySections }}
 {{ $form_count := len $form }}
 
-<article class="mt4 pa3_5 pa3-ns mw7_5 mw7-m nb5 center bg-white br-20 mh3-l mh3-ns cus-shed">
+<article class="ma4 pa3_5 pa3-ns mw7_5 mw7-m center bg-white br-20 mh3-l mh3-ns cus-shed">
     <div class="db no-underline dark-gray">
         <div class="flex flex-auto flex-column-ns">
             <div class="bg-dark-gray max-h-40 w-100-ns w-45 lh0 mw-3-l br-10 overflow-hidden ">

--- a/layouts/partials/img-left-plus-right.html
+++ b/layouts/partials/img-left-plus-right.html
@@ -10,7 +10,7 @@
 {{ $sections_count_left := len $sections_left }}
 
 {{ if ge $sections_count_left 1 }}
-<div class="pv3 ph4 pa4-l ph3-ns pv0-ns w-100 mw8-5 center">
+<div class="pt3 ph4 pt4-l ph4-l ph3-ns pv0-ns w-100 mw8-5 center">
     {{ if .Params.section_title_one }}
         <h2 class="lh-copy f3-l f4 mt0 mb4" style="color:{{ $.Param "middle_title_color" | default "#181818" }};" >
             {{ .Params.section_title_one }}
@@ -32,7 +32,7 @@
 {{ $sections_count_right := len $sections_right }}
 
 {{ if ge $sections_count_right 1 }}
-<div class="pa3 pa4-l ph4-m w-100 ph3-ns pv0-ns mw8-5 center">
+<div class="pt3 ph3 ph4-l pt4-l ph4-m w-100 ph3-ns pv0-ns mw8-5 center">
     {{ if .Params.section_title_two }}
     <div class="lh-copy f4 ph0-ns" style="color:{{ $.Param "middle_title_color" | default "#181818" }};" >
         <h2 class="lh-copy f3-l f4" >

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -8,8 +8,8 @@
     <div class="bg-black-30">
       {{ partial "site-navigation.html" . }}
         {{ if not .Params.omit_header_text }}
-        <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
-          <h1 class="header-title-font f2 f1-l f3-ns white-90 lh-title">{{ .Title | default .Site.Title }}</h1>
+        <div class="tc p-banner-lg ph3 ph4-ns w-90 w-100-ns center">
+          <h1 class="header-title-font f2 f2-l f3-ns white-90 lh-title">{{ .Title | default .Site.Title }}</h1>
           {{ with .Params.description  }}
             <h2 class="fw1 f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4">
               {{ . }}
@@ -17,8 +17,8 @@
           {{ end }}
         </div>
         {{ else }}
-        <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
-          <h1 class="header-title-font f2 f1-l f3-ns white-90 lh-title">{{ .Title | default .Site.Title }}</h1>
+        <div class="tc p-banner-lg ph3 ph4-ns w-90 w-100-ns center">
+          <h1 class="header-title-font f2 f2-l f3-ns white-90 lh-title">{{ .Title | default .Site.Title }}</h1>
         </div>
         {{ end }}
     </div>
@@ -70,8 +70,8 @@
   <header class="cover bg-center" style="background-image: url('{{ $featured_image }}');">
     <div class="bg-black-30">
       {{ if not .Params.omit_header_text }}
-      <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
-        <h1 class="header-title-font f2 f1-l f3-ns white-90 lh-title">{{ .Title | default .Site.Title }}</h1>
+      <div class="tc p-banner-lg ph3 ph4-ns w-90 w-100-ns center">
+        <h1 class="header-title-font f2 f2-l f3-ns white-90 lh-title">{{ .Title | default .Site.Title }}</h1>
         {{ with .Params.description  }}
         <h2 class="fw1 f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4">
           {{ . }}
@@ -79,8 +79,8 @@
         {{ end }}
       </div>
       {{ else }}
-      <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
-        <h1 class="header-title-font f2 f1-l f3-ns white-90 lh-title">{{ .Title | default .Site.Title }}</h1>
+      <div class="tc p-banner-lg ph3 ph4-ns w-90 w-100-ns center">
+        <h1 class="header-title-font f2 f2-l f3-ns white-90 lh-title">{{ .Title | default .Site.Title }}</h1>
       </div>
       {{ end }}
     </div>

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -17,7 +17,7 @@
           {{ end }}
         </div>
         {{ else }}
-        <div class="tc p-banner-sm ph3 ph4-ns w-70 w-100-ns center">
+        <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
           <h1 class="header-title-font f2 f1-l f3-ns white-90 lh-title">{{ .Title | default .Site.Title }}</h1>
         </div>
         {{ end }}
@@ -70,7 +70,7 @@
   <header class="cover bg-center" style="background-image: url('{{ $featured_image }}');">
     <div class="bg-black-30">
       {{ if not .Params.omit_header_text }}
-      <div class="tc p-banner-lg p-banner-lg-ns ph3 ph4-ns w-70 w-100-ns center">
+      <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
         <h1 class="header-title-font f2 f1-l f3-ns white-90 lh-title">{{ .Title | default .Site.Title }}</h1>
         {{ with .Params.description  }}
         <h2 class="fw1 f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4">
@@ -79,7 +79,7 @@
         {{ end }}
       </div>
       {{ else }}
-      <div class="tc p-banner-sm p-banner-sm-ns ph3 ph4-ns w-70 w-100-ns center">
+      <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
         <h1 class="header-title-font f2 f1-l f3-ns white-90 lh-title">{{ .Title | default .Site.Title }}</h1>
       </div>
       {{ end }}

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -7,8 +7,8 @@
   <header class="cover bg-center" style="background-image: url('{{ $featured_image }}');z-index:1;">
     <div class="{{ .Site.Params.cover_dimming_class | default "bg-black-30" }}">
       {{ partial "site-navigation.html" .}}
-      <div class="tc-l pv6 ph3 ph4-ns">
-        <h1 class="header-title-font f2 f1-l f3-ns fw2 white-90 mv4 lh-title">
+      <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
+        <h1 class="header-title-font f2 f1-l f3-ns white-90 lh-title">
           {{ .Title | default .Site.Title }}
         </h1>
         {{ with .Params.description }}
@@ -23,8 +23,8 @@
   <header>
     <div class="pb3-m pb6-l {{ .Site.Params.background_color_class | default "bg-black" }}">
       {{ partial "site-navigation.html" . }}
-      <div class="tc-l pv3 ph3 ph4-ns">
-        <h1 class="header-title-font f1 f2-ns f-subheadline-l fw2 light-silver mb0 lh-title">
+      <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
+        <h1 class="header-title-font f2 f1-l f3-ns white-90 lh-title">
           {{ .Title | default .Site.Title }}
         </h1>
         {{ with .Params.description }}
@@ -75,7 +75,7 @@
   {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
   <header class="cover bg-center relative" style="background-image: url('{{ $featured_image }}');z-index:1;">
     <div class="{{ .Site.Params.cover_dimming_class | default "bg-black-30" }}">
-    <div class="tc-l pv6 ph3 ph4-ns">
+    <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
       <h1 class="header-title-font f1 f2-ns f-subheadline-l fw2 white-90 mv4 lh-title">
         {{ .Title | default .Site.Title }}
       </h1>
@@ -90,7 +90,7 @@
   {{ else }}
   <header class="relative" style="z-index:1;">
     <div class="{{ .Site.Params.background_color_class | default "bg-black" }}">
-    <div class="tc-l pv6 ph3 ph4-ns">
+    <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
       <h1 class="header-title-font f1 f2-ns f-subheadline-l fw2 white-90 mv4 lh-title">
         {{ .Title | default .Site.Title }}
       </h1>

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -7,8 +7,8 @@
   <header class="cover bg-center" style="background-image: url('{{ $featured_image }}');z-index:1;">
     <div class="{{ .Site.Params.cover_dimming_class | default "bg-black-30" }}">
       {{ partial "site-navigation.html" .}}
-      <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
-        <h1 class="header-title-font f2 f1-l f3-ns white-90 lh-title">
+      <div class="tc p-banner-lg ph3 ph4-ns w-90 w-100-ns center">
+        <h1 class="header-title-font f2 f2-l f3-ns white-90 lh-title">
           {{ .Title | default .Site.Title }}
         </h1>
         {{ with .Params.description }}
@@ -23,8 +23,8 @@
   <header>
     <div class="pb3-m pb6-l {{ .Site.Params.background_color_class | default "bg-black" }}">
       {{ partial "site-navigation.html" . }}
-      <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
-        <h1 class="header-title-font f2 f1-l f3-ns white-90 lh-title">
+      <div class="tc p-banner-lg ph3 ph4-ns w-90 w-100-ns center">
+        <h1 class="header-title-font f2 f2-l f3-ns white-90 lh-title">
           {{ .Title | default .Site.Title }}
         </h1>
         {{ with .Params.description }}
@@ -75,8 +75,8 @@
   {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
   <header class="cover bg-center relative" style="background-image: url('{{ $featured_image }}');z-index:1;">
     <div class="{{ .Site.Params.cover_dimming_class | default "bg-black-30" }}">
-    <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
-      <h1 class="header-title-font f1 f2-ns f-subheadline-l fw2 white-90 mv4 lh-title">
+    <div class="tc p-banner-lg ph3 ph4-ns w-90 w-100-ns center">
+      <h1 class="header-title-font f2 f2-l f3-ns white-90 lh-title">
         {{ .Title | default .Site.Title }}
       </h1>
       {{ with .Params.description }}
@@ -90,8 +90,8 @@
   {{ else }}
   <header class="relative" style="z-index:1;">
     <div class="{{ .Site.Params.background_color_class | default "bg-black" }}">
-    <div class="tc p-banner-lg ph3 ph4-ns w-70 w-100-ns center">
-      <h1 class="header-title-font f1 f2-ns f-subheadline-l fw2 white-90 mv4 lh-title">
+    <div class="tc p-banner-lg ph3 ph4-ns w-90 w-100-ns center">
+      <h1 class="header-title-font f2 f2-l f3-ns white-90 lh-title">
         {{ .Title | default .Site.Title }}
       </h1>
       {{ with .Params.description }}


### PR DESCRIPTION
Closes #63 
Corrected cookies banner in phone and other versions.
Added margin between the line in the footer and the contact form.
Made the size of the main banner the same on every page.
Removed final masage before footer.
Correct 'up to top' button.
Correct 'contact us' button margin.
